### PR TITLE
Add structured logging and domain-based selection

### DIFF
--- a/services/hass_helper/README.md
+++ b/services/hass_helper/README.md
@@ -1,9 +1,9 @@
 # HASS Helper Service
 
 This service provides a small FastAPI application that connects to a Home Assistant instance,
-collects entity and device metadata filtered by configured integrations, and stores the results
-locally as JSON files. A lightweight web UI is bundled to manage integrations, blacklists, and
-whitelists, and to trigger ingestion runs.
+collects entity and device metadata filtered by configured domains, and stores the results locally
+as JSON files. A lightweight web UI is bundled to manage domains, blacklists, and whitelists, and
+to trigger ingestion runs.
 
 ## Configuration
 
@@ -25,7 +25,7 @@ cp services/hass_helper/.env.example services/hass_helper/.env
 
 The service reads and persists JSON data inside `services/hass_helper/data/`:
 
-- `integrations.json` – Selected integration entries used during ingest.
+- `integrations.json` – Selected Home Assistant domains used during ingest.
 - `entities.json` – Cached entities and devices from the most recent ingest run.
 - `blacklist.json` – Entity and device IDs excluded during ingest.
 - `whitelist.json` – Entity IDs that override blacklist filtering.
@@ -61,3 +61,16 @@ docker compose up --build
 ```
 
 Once the container is running, browse to `http://localhost:8000/` to use the UI.
+
+### Log viewing with Dozzle
+
+Structured JSON logs are emitted to stdout for every Home Assistant HTTP call and key ingest
+operations. A companion Compose file is provided to run [Dozzle](https://dozzle.dev/) for viewing
+these logs alongside the application:
+
+```bash
+cd services/hass_helper
+docker compose -f docker-compose.yml -f docker-compose.infra.yaml up
+```
+
+Dozzle is exposed on `http://localhost:9999/` and is pre-filtered to the `hass-helper` container.

--- a/services/hass_helper/docker-compose.infra.yaml
+++ b/services/hass_helper/docker-compose.infra.yaml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: hass-helper-dozzle
+    restart: unless-stopped
+    environment:
+      DOZZLE_ENABLE_AUTH: "false"
+      DOZZLE_FILTER: hass-helper
+    ports:
+      - "9999:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - hass-helper

--- a/services/hass_helper/logging_config.py
+++ b/services/hass_helper/logging_config.py
@@ -1,0 +1,91 @@
+"""Logging helpers for the hass_helper service."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+
+_RESERVED_LOG_RECORD_FIELDS = {
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+}
+
+
+def _serialise(value: Any) -> Any:
+    """Return a JSON-serialisable representation of *value*."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(key): _serialise(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_serialise(item) for item in value]
+    return str(value)
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter that renders log records as JSON objects."""
+
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
+    default_msec_format = "%s.%03dZ"
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited docstring
+        payload: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.default_time_format),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _RESERVED_LOG_RECORD_FIELDS
+        }
+        if extras:
+            payload.update({key: _serialise(value) for key, value in extras.items()})
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = record.stack_info
+
+        return json.dumps(payload, separators=(",", ":"))
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure structured logging for the hass_helper service."""
+
+    logger = logging.getLogger("hass_helper")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    http_logger = logging.getLogger("hass_helper.http")
+    http_logger.setLevel(logging.DEBUG)
+
+
+__all__ = ["setup_logging"]
+

--- a/services/hass_helper/models.py
+++ b/services/hass_helper/models.py
@@ -6,14 +6,13 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 
-class IntegrationEntry(BaseModel):
-    entry_id: str = Field(..., description="Unique identifier of the integration entry")
-    domain: Optional[str] = Field(None, description="Integration domain")
+class DomainEntry(BaseModel):
+    domain: str = Field(..., description="Home Assistant domain identifier")
     title: Optional[str] = Field(None, description="Human readable name")
 
 
-class IntegrationSelectionRequest(BaseModel):
-    integration_id: str = Field(..., description="Identifier of the integration entry")
+class DomainSelectionRequest(BaseModel):
+    domain: str = Field(..., description="Domain to include during ingest")
 
 
 class EntitiesIngestResponse(BaseModel):

--- a/services/hass_helper/static/index.html
+++ b/services/hass_helper/static/index.html
@@ -19,22 +19,21 @@
       <section id="entity-tab" class="tab-content active">
         <article class="panel">
           <div class="panel-header">
-            <h2>Integrations</h2>
+            <h2>Domains</h2>
             <div class="panel-actions">
-              <button id="refresh-integrations" class="secondary">Refresh</button>
-              <button id="add-integration" class="primary">Add integration</button>
+              <button id="refresh-domains" class="secondary">Refresh</button>
+              <button id="add-domain" class="primary">Add domain</button>
             </div>
           </div>
           <p>
-            The integrations listed below are used when ingesting entities and devices.
-            Add additional integrations to include their entities in the export.
+            The domains listed below determine which integrations are queried when ingesting
+            entities and devices. Add additional domains to include their entities in the export.
           </p>
-          <table id="integrations-table">
+          <table id="domains-table">
             <thead>
               <tr>
-                <th>Title</th>
                 <th>Domain</th>
-                <th>Entry ID</th>
+                <th>Display name</th>
                 <th class="actions">Actions</th>
               </tr>
             </thead>
@@ -165,15 +164,15 @@
       </section>
     </main>
 
-    <div class="modal" id="integration-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal" id="domain-modal" role="dialog" aria-modal="true" aria-hidden="true">
       <div class="modal-content">
-        <h3>Select an integration</h3>
-        <p>Select a Home Assistant integration to add to the ingest list.</p>
-        <label for="integration-select" class="muted">Available integrations</label>
-        <select id="integration-select"></select>
+        <h3>Select a domain</h3>
+        <p>Select a Home Assistant domain to add to the ingest list.</p>
+        <label for="domain-select" class="muted">Available domains</label>
+        <select id="domain-select"></select>
         <div class="modal-actions">
-          <button id="cancel-integration" class="secondary">Cancel</button>
-          <button id="confirm-integration" class="primary">Add</button>
+          <button id="cancel-domain" class="secondary">Cancel</button>
+          <button id="confirm-domain" class="primary">Add</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add structured JSON logging for Home Assistant API calls and ingestion actions
- update domain selection flow in the API and UI, including sorted domain options
- document the changes and provide an infra docker-compose file with Dozzle for log viewing

## Testing
- python -m compileall services/hass_helper

------
https://chatgpt.com/codex/tasks/task_e_68cbeb0c49cc832ea65aed360cd68026