### PR TITLE
Improve auto-lock failure handling

### DIFF
--- a/blueprints/auto_lock.yaml
+++ b/blueprints/auto_lock.yaml
@@ -126,10 +126,23 @@ action:
                       message: !input notify_message_success
             # Failure path: lock did not confirm
             default:
-              - service: !input notify_service
-                data:
-                  title: !input notify_title_failed
-                  message: !input notify_message_failed
+              - choose:
+                  # Final check: lock eventually reported locked even though wait timed out
+                  - conditions:
+                      - condition: state
+                        entity_id: !input lock_entity
+                        state: "locked"
+                    sequence:
+                      - service: !input notify_service
+                        data:
+                          title: !input notify_title_success
+                          message: !input notify_message_success
+                # Still not locked -> report failure
+                default:
+                  - service: !input notify_service
+                    data:
+                      title: !input notify_title_failed
+                      message: !input notify_message_failed
 
     # ❌ Door is OPEN -> notify (no lock attempt)
     default:


### PR DESCRIPTION
## Summary
- add a final state check when the lock confirmation wait times out
- send the success notification if the lock eventually reports locked, otherwise fall back to the failure notification

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf090f51fc832ea82b6c278a6428f8